### PR TITLE
introduce ddctuil property in default config object for Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ To display the module insert it in the config.js file.
  | wrandrForceMode | **-mode 3 only-** Force screen resolution mode | String | null |
  | waylandDisplayName | **-mode 3 or mode 7 only-** Wayland display name (generaly `wayland-0` or `wayland-1`) | String | wayland-0 |
  | relayGPIOPin | **-mode 8 only-** GPIO pin of the relay | Number | 1 |
+ | ddcutil | adjust feature codes of setvcp command for power on (**powerOnCode**) and off (**powerOffCode**), and to skip check after setvcp commands (**skipSetVcpCheck**) | Object | {powerOnCode: "1", powerOffCode: "4", skipSetVcpCheck: false} 
 
  * Available style:
    - `style: 0` - Don't display Count-up bar in screen
@@ -134,7 +135,10 @@ To display the module insert it in the config.js file.
 
 Note:<br>
 It's possible that `pinctrl` tool is not installed by default on your system (raspbian 11)<br>
-You can install it by using this command in your `MMM-Pir` folder: `npm run pinctrl`
+You can install it by using this command in your `MMM-Pir` folder: `npm run pinctrl`<br>
+
+Note for ddcutil:<br>
+For some displays, the `getvcp` commands cause the display to turn-on. In these cases it could be useful to set the display config value of `ddcutil.skipSetVcpCheck` to `true`.<br>
 
 ------
 #### Pir Sensor Configuration

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To display the module insert it in the config.js file.
  | wrandrForceMode | **-mode 3 only-** Force screen resolution mode | String | null |
  | waylandDisplayName | **-mode 3 or mode 7 only-** Wayland display name (generaly `wayland-0` or `wayland-1`) | String | wayland-0 |
  | relayGPIOPin | **-mode 8 only-** GPIO pin of the relay | Number | 1 |
- | ddcutil | adjust feature codes of setvcp command for power on (**powerOnCode**) and off (**powerOffCode**), and to skip check after setvcp commands (**skipSetVcpCheck**) | Object | {powerOnCode: "1", powerOffCode: "4", skipSetVcpCheck: false} 
+ | ddcutil | adjust feature codes of setvcp command for power on (**powerOnCode**) and off (**powerOffCode**), and to skip check after setvcp commands (**skipSetVcpCheck**) | Object | {powerOnCode: "01", powerOffCode: "04", skipSetVcpCheck: false} 
 
  * Available style:
    - `style: 0` - Don't display Count-up bar in screen

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cron-parser": "^4.9.0",
         "esbuild": "^0.24.2",
         "glob": "^11.0.0",
+        "lodash": "^4.17.21",
         "long-press-event": "^2.5.0",
         "nan": "^2.22.0",
         "node-cron": "^3.0.3",
@@ -3587,6 +3588,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cron-parser": "^4.9.0",
     "esbuild": "^0.24.2",
     "glob": "^11.0.0",
+    "lodash": "^4.17.21",
     "long-press-event": "^2.5.0",
     "nan": "^2.22.0",
     "node-cron": "^3.0.3",

--- a/src/components/screenLib.js
+++ b/src/components/screenLib.js
@@ -11,7 +11,7 @@ const lodash = require("lodash");
 var log = () => { /* do nothing */ };
 
 class SCREEN {
-  constructor (config, callback) {
+  constructor(config, callback) {
     this.config = config;
     this.sendSocketNotification = callback.sendSocketNotification;
     this.governor = callback.governor;
@@ -27,13 +27,13 @@ class SCREEN {
       wrandrForceRotation: "normal",
       wrandrForceMode: null,
       waylandDisplayName: "wayland-0",
-      ddcutil : {
-        powerOnCode : "1",
-        powerOffCode : "4",
-        skipSetVcpCheck : false
+      ddcutil: {
+        powerOnCode: "01",
+        powerOffCode: "04",
+        skipSetVcpCheck: false
       }
     };
-    this.config = lodash.defaultsDeep(this.config,this.default,{});
+    this.config = lodash.defaultsDeep(this.config, this.default, {});
     if (this.config.debug) log = (...args) => { console.log("[MMM-Pir] [LIB] [SCREEN]", ...args); };
     this.screen = {
       mode: this.config.mode,
@@ -157,7 +157,7 @@ class SCREEN {
     this.screenStatus();
   }
 
-  activate () {
+  activate() {
     process.on("exit", () => {
       if (this.config.mode) this.setPowerDisplay(true);
       this.governor("WORKING");
@@ -165,7 +165,7 @@ class SCREEN {
     this.start();
   }
 
-  start (restart) {
+  start(restart) {
     if (this.screen.locked || this.screen.running) return;
     if (!restart) log("Start.");
     else log("Restart.");
@@ -217,7 +217,7 @@ class SCREEN {
     }, 1000);
   }
 
-  forceTurnOffScreen () {
+  forceTurnOffScreen() {
     if (!this.screen.power) return log("forceTurnOffScreen: already off");
     this.sendSocketNotification("SCREEN_HIDING");
     this.screen.power = false;
@@ -227,7 +227,7 @@ class SCREEN {
     this.sendSocketNotification("SCREEN_PRESENCE", false);
   }
 
-  stop () {
+  stop() {
     if (this.screen.locked) return;
 
     if (!this.screen.power) {
@@ -244,7 +244,7 @@ class SCREEN {
     log("Stops.");
   }
 
-  reset () {
+  reset() {
     if (this.screen.locked) return;
     clearInterval(this.interval);
     this.interval = null;
@@ -252,12 +252,12 @@ class SCREEN {
     this.start(true);
   }
 
-  wakeup () {
+  wakeup() {
     if (this.screen.locked) return;
     this.reset();
   }
 
-  lock () {
+  lock() {
     if (this.screen.locked) return;
     this.screen.locked = true;
     clearInterval(this.interval);
@@ -266,14 +266,14 @@ class SCREEN {
     log("Locked !");
   }
 
-  unlock () {
+  unlock() {
     if (this.screen.forceLocked) return log("Unlock: ForceLocked");
     this.screen.locked = false;
     log("Unlocked !");
     this.start();
   }
 
-  forceEnd () {
+  forceEnd() {
     if (this.screen.forceLocked) return log("forceEnd: ForceLocked");
     clearInterval(this.interval);
     this.interval = null;
@@ -282,7 +282,7 @@ class SCREEN {
     this.forceTurnOffScreen();
   }
 
-  wantedPowerDisplay (wanted) {
+  wantedPowerDisplay(wanted) {
     var actual = false;
     switch (this.config.mode) {
       case 0:
@@ -445,7 +445,7 @@ class SCREEN {
     }
   }
 
-  resultDisplay (actual, wanted) {
+  resultDisplay(actual, wanted) {
     if (this.screen.forceOnStart) {
       log("Display: Force On Start");
       this.setPowerDisplay(true);
@@ -458,7 +458,7 @@ class SCREEN {
     }
   }
 
-  async setPowerDisplay (set) {
+  async setPowerDisplay(set) {
     log(`Display ${set ? "ON." : "OFF."}`);
     this.screen.power = set;
     // and finally apply rules !
@@ -549,7 +549,7 @@ class SCREEN {
             if (err) {
               console.error(`[MMM-Pir] [LIB] [SCREEN] mode 5, power ON: ${err}`);
               this.sendSocketNotification("SCREEN_ERROR", "ddcutil command error (mode 5 power ON)");
-            } else if(!this.config.ddcutil.skipSetVcpCheck){
+            } else if (!this.config.ddcutil.skipSetVcpCheck) {
               // 5 second delay
               setTimeout(() => {
                 exec("ddcutil getvcp d6", (err, stdout) => {
@@ -560,7 +560,7 @@ class SCREEN {
                   else {
                     let responseSh = stdout.trim();
                     var displaySh = responseSh.split("(sl=")[1];
-                    if (displaySh !== "0x01)") {
+                    if (displaySh !== `0x${this.config.ddcutil.powerOnCode})`) {
                       console.error(`[MMM-Pir] [LIB] [SCREEN] ddcutil Error ${responseSh}`);
                       this.sendSocketNotification("SCREEN_ERROR", "ddcutil command error (mode 5 power ON verify)");
                     }
@@ -574,7 +574,7 @@ class SCREEN {
             if (err) {
               console.error(`[MMM-Pir] [LIB] [SCREEN] mode 5, power OFF: ${err}`);
               this.sendSocketNotification("SCREEN_ERROR", "ddcutil command error (mode 5 power OFF)");
-            } else if(!this.config.skipSetVcpCheck){
+            } else if (!this.config.ddcutil.skipSetVcpCheck) {
               // 1 second delay
               setTimeout(() => {
                 exec("ddcutil getvcp d6", (err, stdout) => {
@@ -585,7 +585,7 @@ class SCREEN {
                   else {
                     let responseSh = stdout.trim();
                     var displaySh = responseSh.split("(sl=")[1];
-                    if (displaySh !== "0x04)") {
+                    if (displaySh !== `0x${this.config.ddcutil.powerOffCode})`) {
                       console.error(`[MMM-Pir] [LIB] [SCREEN] ddcutil Error ${responseSh}`);
                       this.sendSocketNotification("SCREEN_ERROR", "ddcutil command error (mode 5 power OFF verify)");
                     }
@@ -653,22 +653,22 @@ class SCREEN {
     }
   }
 
-  state () {
+  state() {
     this.sendSocketNotification("SCREEN_STATE", this.screen);
   }
 
-  SendScreenPowerState () {
+  SendScreenPowerState() {
     this.sendSocketNotification("SCREEN_POWER", this.screen.power);
   }
 
-  sleep (ms = 1300) {
+  sleep(ms = 1300) {
     return new Promise((resolve) => {
       this.screen.awaitBeforeTurnOffTimer = setTimeout(resolve, ms);
     });
   }
 
   /** Cron Rules **/
-  cronState (state) {
+  cronState(state) {
     this.screen.cronStarted = state.started;
     this.screen.cronON = state.ON;
     this.screen.cronOFF = state.OFF;
@@ -711,7 +711,7 @@ class SCREEN {
   }
 
   /** Force Lock ON/OFF display **/
-  forceLockOFF () {
+  forceLockOFF() {
     if (!this.screen.power) return log("[Force OFF] Display Already OFF");
     if (this.screen.cronStarted && this.screen.cronON && this.screen.cronMode === 2) return log("[Force OFF] Display is Locked by cron!");
     this.sendForceLockState(true);
@@ -725,7 +725,7 @@ class SCREEN {
     log("[Force OFF] Turn OFF Display");
   }
 
-  forceLockON () {
+  forceLockON() {
     if (this.screen.locked && !this.screen.forceLocked) return log("[Force ON] Display is Locked!");
     if (this.screen.cronStarted) {
       if (this.screen.cronON) {
@@ -744,17 +744,17 @@ class SCREEN {
     log("[Force ON] Turn ON Display");
   }
 
-  forceLockToggle () {
+  forceLockToggle() {
     if (this.screen.power) this.forceLockOFF();
     else this.forceLockON();
   }
 
-  sendForceLockState (state) {
+  sendForceLockState(state) {
     this.screen.forceLocked = state;
     this.sendSocketNotification("SCREEN_FORCELOCKED", this.screen.forceLocked);
   }
 
-  screenStatus () {
+  screenStatus() {
     setInterval(() => {
       if (this.screen.power && this.config.availability) this.screen.availabilityCounter++;
       let status = this.screen.power;

--- a/src/node_helper.js
+++ b/src/node_helper.js
@@ -11,14 +11,14 @@ const LibCron = require("./components/cronJob");
 const LibGovernor = require("./components/governorLib");
 
 module.exports = NodeHelper.create({
-  start () {
+  start() {
     this.pir = null;
     this.screen = null;
     this.cron = null;
     this.governor = null;
   },
 
-  socketNotificationReceived (notification, payload) {
+  socketNotificationReceived(notification, payload) {
     switch (notification) {
       case "INIT":
         this.config = payload;
@@ -48,7 +48,7 @@ module.exports = NodeHelper.create({
     }
   },
 
-  async parse () {
+  async parse() {
     if (this.config.debug) log = (...args) => { console.log("[MMM-Pir]", ...args); };
     console.log("[MMM-Pir] Version:", require("./package.json").version, "rev:", require("./package.json").rev);
     log("Config:", this.config);
@@ -114,7 +114,8 @@ module.exports = NodeHelper.create({
       wrandrForceRotation: this.config.Display.wrandrForceRotation,
       wrandrForceMode: this.config.Display.wrandrForceMode,
       waylandDisplayName: this.config.Display.waylandDisplayName,
-      animate: this.config.Display.animate
+      animate: this.config.Display.animate,
+      ddcutil: this.config.Display.ddcutil
     };
 
     let cronConfig = {


### PR DESCRIPTION
Allows the usage in mode:5 (ddctuil) also for those screens that turn-on when called for `getcvp D6` commands after a turn-on/off. To skip the after-set check, the user can set a flag (`skipSetVcpCheck`) via the config.

Moreover, the user can now arbitrarly choose the feature codes for turn-on and -off (with `powerOnCode `and `powerOffCode`) via config.

The fork includes updates in `README.md`