### PR TITLE
setPowerRetries in ddcutil config allows for retries of power-on on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ To display the module insert it in the config.js file.
       ddcutil: {
         powerOnCode: "01",
         powerOffCode: "04",
-        skipSetVcpCheck: false
+        skipSetVcpCheck: false,
+        setPowerRetries: 0
       }
     },
     Pir: {
@@ -118,7 +119,7 @@ To display the module insert it in the config.js file.
  | wrandrForceMode | **-mode 3 only-** Force screen resolution mode | String | null |
  | waylandDisplayName | **-mode 3 or mode 7 only-** Wayland display name (generaly `wayland-0` or `wayland-1`) | String | wayland-0 |
  | relayGPIOPin | **-mode 8 only-** GPIO pin of the relay | Number | 1 |
- | ddcutil | **-mode 5 only-** Adjust feature codes of setvcp command for power on (**powerOnCode**) and off (**powerOffCode**), and to skip check after setvcp commands (**skipSetVcpCheck**) | Object | {powerOnCode: "01", powerOffCode: "04", skipSetVcpCheck: false} 
+ | ddcutil | **-mode 5 only-** Adjust feature codes of setvcp command for power on (**powerOnCode**) and off (**powerOffCode**), to skip check after setvcp commands (**skipSetVcpCheck**) and to retry the screen powerOn on startup (**setPowerRetries**) | Object | {powerOnCode: "01", powerOffCode: "04", skipSetVcpCheck: false, setPowerRetries : 0} 
 
  * Available style:
    - `style: 0` - Don't display Count-up bar in screen


### PR DESCRIPTION
This is a proposed solution for #149 

I have used async/await in `wantedPowerDisplay`, `resultDisplay `and `setPowerDisplay`.

I still had problems with LF/CRLF: after pull from original repository, I saw all files having a line-break being CRLF, and set all to LF. I hope to have done well 